### PR TITLE
(v2.1) Display assertion failures in setup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>edu.purdue.cs</groupId>
   <artifactId>barista</artifactId>
-  <version>2.0</version>
+  <version>2.1</version>
 
   <name>Barista</name>
   <description>Grading package for Java Gradescope assignments.</description>


### PR DESCRIPTION
This pull adds a test case when a `@BeforeClass` method fails during testing. This way, these failures are not hidden from both the instructors and the students, allowing for better debugging.

This pull also bumps the version number.