### PR TITLE
(v2.1.1) Fix setup failure error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>edu.purdue.cs</groupId>
   <artifactId>barista</artifactId>
-  <version>2.1</version>
+  <version>2.1.1</version>
 
   <name>Barista</name>
   <description>Grading package for Java Gradescope assignments.</description>

--- a/src/main/java/edu/purdue/cs/barista/GradescopeListener.java
+++ b/src/main/java/edu/purdue/cs/barista/GradescopeListener.java
@@ -19,7 +19,7 @@ import org.junit.runner.notification.RunListener;
  * {@link TestSuite} classes.
  *
  * @author Andrew Davis, drew@drewdavis.me
- * @version 2.1, 06/21/2020
+ * @version 2.1.1, 06/21/2020
  * @since 1.0
  */
 public class GradescopeListener extends RunListener {
@@ -114,14 +114,14 @@ public class GradescopeListener extends RunListener {
      */
     @Override
     public void testFailure(Failure failure) {
-        BeforeClass setup = failure.getDescription().getAnnotation(BeforeClass.class);
+        TestSuite testSuite = failure.getDescription().getAnnotation(TestSuite.class);
 
-        // This is a setup method failure
-        if (setup == null) {
+        // This is a setup/teardown method failure
+        if (testSuite != null) {
             String testSuiteName = failure.getDescription().getTestClass().getSimpleName();
             GradedTestResult result = new GradedTestResult(
-                testSuiteName + ": Setup",
-                "0",
+                "INFO: " + testSuiteName,
+                "",
                 0.0,
                 TestCase.Visibility.VISIBLE.toString()
             );


### PR DESCRIPTION
This pull fixes an issue from v2.1 (#5) where tests that pass would erroneously show setup test case failures. `@TestSuite` is the annotation from the thrown failure, not `@BeforeClass`, so this was also fixed.

This pull also bumps the version number.