### PR TITLE
Add build & deploy scripts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,10 @@ jobs:
 
       - name: Build
         run: mvn compile
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test
         run: mvn test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: Build and test
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup JDK and Maven
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+
+      - name: Load Maven repository from cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Build
+        run: mvn compile
+
+      - name: Test
+        run: mvn test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,5 @@
 name: Build and test
-on:
-  push:
-    branches-ignore:
-      - master
+on: pull_request
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build and test
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup JDK and Maven
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 11
 
       - name: Load Maven repository from cache
         uses: actions/cache@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,8 @@
 name: Deploy
 on: push
-#  push:
-#    branches:
-#      - master
+  push:
+    branches:
+      - master
 
 jobs:
   package:
@@ -29,10 +29,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-#      - name: Deploy
-#        run: mvn deploy
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Deploy
+        run: mvn deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   javadoc:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,10 +42,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Checkout docs
+      - name: Checkout gh-pages
         uses: actions/checkout@v2
         with:
-          ref: docs
+          ref: gh-pages
           path: target/site/apidocs
 
       - name: Setup JDK and Maven
@@ -69,7 +69,7 @@ jobs:
         run: |
           cd target/site/apidocs
           repo="https://${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
-          branch="docs"
+          branch="gh-pages"
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
           git add -A

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,73 @@
+name: Deploy
+on: push
+#  push:
+#    branches:
+#      - master
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup JDK and Maven
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+
+      - name: Load Maven repository from cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Build
+        run: mvn package
+
+      - name: Deploy
+        run: mvn deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  javadoc:
+    runs-on: ubuntu-latest
+    needs: package
+
+    steps:
+      - name: Checkout
+          uses: actions/checkout@v2
+
+      - name: Checkout docs
+        uses: actions/checkout@v2
+        with:
+          ref: docs
+          path: target/site/apidocs
+
+      - name: Setup JDK and Maven
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+
+      - name: Load Maven repository from cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Build
+        run: mvn javadoc:javadoc
+
+      - name: Deploy
+        run: |
+          cd target/site/apidocs
+          repo="https://${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+          branch="docs"
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git add -A
+          git commit -m "Deploy @ ${{ github.sha }}"
+          git push $repo $branch

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,5 @@
 name: Deploy
-on: push
+on:
   push:
     branches:
       - master

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Build
         run: mvn package
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy
         run: mvn deploy
@@ -38,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout
-          uses: actions/checkout@v2
+        uses: actions/checkout@v2
 
       - name: Checkout docs
         uses: actions/checkout@v2
@@ -60,6 +62,8 @@ jobs:
 
       - name: Build
         run: mvn javadoc:javadoc
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup JDK and Maven
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 11
 
       - name: Load Maven repository from cache
         uses: actions/cache@v1
@@ -51,7 +51,7 @@ jobs:
       - name: Setup JDK and Maven
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 11
 
       - name: Load Maven repository from cache
         uses: actions/cache@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,10 +29,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Deploy
-        run: mvn deploy
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#      - name: Deploy
+#        run: mvn deploy
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   javadoc:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Barista
 
+[![build](https://img.shields.io/github/workflow/status/purduecsbridge/barista/Build%20and%20test/master)](https://github.com/purduecsbridge/barista/actions?query=workflow%3A%22Build+and+test%22+branch%3Amaster)
+[![javadoc](https://img.shields.io/badge/docs-javadoc-blue)](https://purduecsbridge.github.io/barista)
+
 Barista is a grading package for Java Gradescope assignments. It is meant to make the development and maintenance of programming assignments easier for courses using Java. How easy is it?
 
 ```java

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Barista
 
-[![build](https://img.shields.io/github/workflow/status/purduecsbridge/barista/Build%20and%20test/master)](https://github.com/purduecsbridge/barista/actions?query=workflow%3A%22Build+and+test%22+branch%3Amaster)
+[![build](https://img.shields.io/github/workflow/status/purduecsbridge/barista/Deploy/master)](https://github.com/purduecsbridge/barista/actions?query=workflow%3A%22Deploy%22+branch%3Amaster)
 [![javadoc](https://img.shields.io/badge/docs-javadoc-blue)](https://purduecsbridge.github.io/barista)
 
 Barista is a grading package for Java Gradescope assignments. It is meant to make the development and maintenance of programming assignments easier for courses using Java. How easy is it?

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,11 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>3.2.0</version>
+        <configuration>
+          <links>
+            <link>https://tkutcher.gitlab.io/jgrade/api/</link>
+          </links>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <version>3.2.0</version>
         <configuration>
           <links>
-            <link>http://tkutcher.gitlab.io/jgrade/api/</link>
+            <link>https://tkutcher.gitlab.io/jgrade/api/</link>
           </links>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>edu.purdue.cs</groupId>
   <artifactId>barista</artifactId>
-  <version>2.1.2</version>
+  <version>3.0</version>
 
   <name>Barista</name>
   <description>Grading package for Java Gradescope assignments.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,7 @@
         <configuration>
           <links>
             <link>https://tkutcher.gitlab.io/jgrade/api/</link>
+            <link>https://junit.org/junit4/javadoc/4.12/</link>
           </links>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -37,9 +37,6 @@
   <properties>
     <!-- https://maven.apache.org/general.html#encoding-warning -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
-    <maven.compiler.source>8</maven.compiler.source>
-    <maven.compiler.target>8</maven.compiler.target>
   </properties>
 
   <distributionManagement>
@@ -83,23 +80,21 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-assembly-plugin</artifactId>
-        <version>3.1.1</version>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
         <configuration>
-          <finalName>${project.artifactId}-${project.version}-all</finalName>
-          <descriptorRefs>
-            <descriptorRef>jar-with-dependencies</descriptorRef>
-          </descriptorRefs>
-          <appendAssemblyId>false</appendAssemblyId>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>single</goal>
-            </goals>
-          </execution>
-        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <source>8</source>
+          <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -91,10 +91,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>3.2.0</version>
-        <configuration>
-          <source>8</source>
-          <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -83,8 +83,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>11</source>
+          <target>11</target>
         </configuration>
       </plugin>
       <plugin>
@@ -93,7 +93,7 @@
         <version>3.2.0</version>
         <configuration>
           <links>
-            <link>https://tkutcher.gitlab.io/jgrade/api/</link>
+            <link>http://tkutcher.gitlab.io/jgrade/api/</link>
           </links>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>edu.purdue.cs</groupId>
   <artifactId>barista</artifactId>
-  <version>2.1.1</version>
+  <version>2.1.2</version>
 
   <name>Barista</name>
   <description>Grading package for Java Gradescope assignments.</description>

--- a/src/main/java/edu/purdue/cs/barista/GradescopeListener.java
+++ b/src/main/java/edu/purdue/cs/barista/GradescopeListener.java
@@ -7,7 +7,6 @@ import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.BeforeClass;
 import org.junit.runner.Description;
 import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunListener;
@@ -19,7 +18,7 @@ import org.junit.runner.notification.RunListener;
  * {@link TestSuite} classes.
  *
  * @author Andrew Davis, drew@drewdavis.me
- * @version 2.1.1, 06/21/2020
+ * @version 2.1.13.0, 06/21/2020
  * @since 1.0
  */
 public class GradescopeListener extends RunListener {
@@ -29,7 +28,7 @@ public class GradescopeListener extends RunListener {
     /**
      * List of test results to pass to Gradescope.
      */
-    private ArrayList<GradedTestResult> testResults;
+    private final ArrayList<GradedTestResult> testResults;
 
     /**
      * The results of the current test being ran.


### PR DESCRIPTION
This pull adds build and deploy scripts to this repository. This not only includes deploys to GitHub Packages for new Barista versions, but also Javadoc deploys to GitHub Pages.

I also decided it was time to start using JDK 11. If someone else is using an older Java version, they should probably upgrade anyway.

----

## Release Notes (3.0)
- Update to JDK 11
  - The Bridge Program has already been using JDK 11, and if you're not, you probably should