### PR TITLE
v3.1.1: Fix divide by zero error when scaling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>edu.purdue.cs</groupId>
   <artifactId>barista</artifactId>
-  <version>3.1</version>
+  <version>3.1.1</version>
 
   <name>Barista</name>
   <description>Grading package for Java Gradescope assignments.</description>

--- a/src/main/java/edu/purdue/cs/barista/GradescopeListener.java
+++ b/src/main/java/edu/purdue/cs/barista/GradescopeListener.java
@@ -153,7 +153,7 @@ public class GradescopeListener extends RunListener {
      */
     void scaleTestCases() {
         final double total = this.testResults.values().stream().mapToDouble(GradedTestResult::getPoints).sum();
-        final double ratio = maxScore / total;
+        final double ratio = total == 0 ? 0 : maxScore / total;
         this.testResults.values().forEach(r -> {
             r.setPoints(r.getPoints() * ratio);
             r.setScore(r.getScore() * ratio);


### PR DESCRIPTION
# Barista
See [project page](https://github.com/purduecsbridge/barista) for more details.

## Release Notes (3.1.1)
- Fix test case scaling
  - There was a bug in test case scaling where if the test cases totaled to `0.0`, the test case point values would be multiplied by `Infinity`. This resulted in the test case point values not being serializable into JSON.
    - Surprisingly, this did not result in an `ArithmeticException` being thrown.
  - It is _highly recommended_ that users upgrade from v3.1, as this will affect student submissions if, unfortunately, a student does not pass any test cases.